### PR TITLE
composer update 2020-11-26

### DIFF
--- a/update/composer.lock
+++ b/update/composer.lock
@@ -941,7 +941,7 @@
         },
         {
             "name": "illuminate/bus",
-            "version": "v8.16.0",
+            "version": "v8.16.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/bus.git",
@@ -994,7 +994,7 @@
         },
         {
             "name": "illuminate/cache",
-            "version": "v8.16.0",
+            "version": "v8.16.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/cache.git",
@@ -1051,7 +1051,7 @@
         },
         {
             "name": "illuminate/collections",
-            "version": "v8.16.0",
+            "version": "v8.16.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/collections.git",
@@ -1105,7 +1105,7 @@
         },
         {
             "name": "illuminate/config",
-            "version": "v8.16.0",
+            "version": "v8.16.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/config.git",
@@ -1153,7 +1153,7 @@
         },
         {
             "name": "illuminate/console",
-            "version": "v8.16.0",
+            "version": "v8.16.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/console.git",
@@ -1213,7 +1213,7 @@
         },
         {
             "name": "illuminate/container",
-            "version": "v8.16.0",
+            "version": "v8.16.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/container.git",
@@ -1264,7 +1264,7 @@
         },
         {
             "name": "illuminate/contracts",
-            "version": "v8.16.0",
+            "version": "v8.16.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/contracts.git",
@@ -1312,7 +1312,7 @@
         },
         {
             "name": "illuminate/events",
-            "version": "v8.16.0",
+            "version": "v8.16.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/events.git",
@@ -1367,7 +1367,7 @@
         },
         {
             "name": "illuminate/filesystem",
-            "version": "v8.16.0",
+            "version": "v8.16.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/filesystem.git",
@@ -1429,7 +1429,7 @@
         },
         {
             "name": "illuminate/macroable",
-            "version": "v8.15.0",
+            "version": "v8.16.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/macroable.git",
@@ -1475,7 +1475,7 @@
         },
         {
             "name": "illuminate/pipeline",
-            "version": "v8.16.0",
+            "version": "v8.16.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/pipeline.git",
@@ -1523,7 +1523,7 @@
         },
         {
             "name": "illuminate/support",
-            "version": "v8.16.0",
+            "version": "v8.16.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/support.git",
@@ -1590,7 +1590,7 @@
         },
         {
             "name": "illuminate/testing",
-            "version": "v8.16.0",
+            "version": "v8.16.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/testing.git",


### PR DESCRIPTION
  - Upgrading illuminate/bus (v8.16.0 => v8.16.1)
  - Upgrading illuminate/cache (v8.16.0 => v8.16.1)
  - Upgrading illuminate/collections (v8.16.0 => v8.16.1)
  - Upgrading illuminate/config (v8.16.0 => v8.16.1)
  - Upgrading illuminate/console (v8.16.0 => v8.16.1)
  - Upgrading illuminate/container (v8.16.0 => v8.16.1)
  - Upgrading illuminate/contracts (v8.16.0 => v8.16.1)
  - Upgrading illuminate/events (v8.16.0 => v8.16.1)
  - Upgrading illuminate/filesystem (v8.16.0 => v8.16.1)
  - Upgrading illuminate/macroable (v8.15.0 => v8.16.1)
  - Upgrading illuminate/pipeline (v8.16.0 => v8.16.1)
  - Upgrading illuminate/support (v8.16.0 => v8.16.1)
  - Upgrading illuminate/testing (v8.16.0 => v8.16.1)
