### PR TITLE
composer update 2021-03-04

### DIFF
--- a/update/composer.lock
+++ b/update/composer.lock
@@ -1031,7 +1031,7 @@
         },
         {
             "name": "illuminate/bus",
-            "version": "v8.30.0",
+            "version": "v8.30.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/bus.git",
@@ -1084,7 +1084,7 @@
         },
         {
             "name": "illuminate/cache",
-            "version": "v8.30.0",
+            "version": "v8.30.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/cache.git",
@@ -1141,7 +1141,7 @@
         },
         {
             "name": "illuminate/collections",
-            "version": "v8.30.0",
+            "version": "v8.30.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/collections.git",
@@ -1195,7 +1195,7 @@
         },
         {
             "name": "illuminate/config",
-            "version": "v8.30.0",
+            "version": "v8.30.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/config.git",
@@ -1243,7 +1243,7 @@
         },
         {
             "name": "illuminate/console",
-            "version": "v8.30.0",
+            "version": "v8.30.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/console.git",
@@ -1303,7 +1303,7 @@
         },
         {
             "name": "illuminate/container",
-            "version": "v8.30.0",
+            "version": "v8.30.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/container.git",
@@ -1354,7 +1354,7 @@
         },
         {
             "name": "illuminate/contracts",
-            "version": "v8.30.0",
+            "version": "v8.30.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/contracts.git",
@@ -1402,7 +1402,7 @@
         },
         {
             "name": "illuminate/events",
-            "version": "v8.30.0",
+            "version": "v8.30.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/events.git",
@@ -1457,7 +1457,7 @@
         },
         {
             "name": "illuminate/filesystem",
-            "version": "v8.30.0",
+            "version": "v8.30.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/filesystem.git",
@@ -1519,7 +1519,7 @@
         },
         {
             "name": "illuminate/macroable",
-            "version": "v8.30.0",
+            "version": "v8.30.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/macroable.git",
@@ -1565,7 +1565,7 @@
         },
         {
             "name": "illuminate/pipeline",
-            "version": "v8.30.0",
+            "version": "v8.30.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/pipeline.git",
@@ -1613,7 +1613,7 @@
         },
         {
             "name": "illuminate/support",
-            "version": "v8.30.0",
+            "version": "v8.30.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/support.git",
@@ -1681,7 +1681,7 @@
         },
         {
             "name": "illuminate/testing",
-            "version": "v8.30.0",
+            "version": "v8.30.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/testing.git",


### PR DESCRIPTION
  - Upgrading illuminate/bus (v8.30.0 => v8.30.1)
  - Upgrading illuminate/cache (v8.30.0 => v8.30.1)
  - Upgrading illuminate/collections (v8.30.0 => v8.30.1)
  - Upgrading illuminate/config (v8.30.0 => v8.30.1)
  - Upgrading illuminate/console (v8.30.0 => v8.30.1)
  - Upgrading illuminate/container (v8.30.0 => v8.30.1)
  - Upgrading illuminate/contracts (v8.30.0 => v8.30.1)
  - Upgrading illuminate/events (v8.30.0 => v8.30.1)
  - Upgrading illuminate/filesystem (v8.30.0 => v8.30.1)
  - Upgrading illuminate/macroable (v8.30.0 => v8.30.1)
  - Upgrading illuminate/pipeline (v8.30.0 => v8.30.1)
  - Upgrading illuminate/support (v8.30.0 => v8.30.1)
  - Upgrading illuminate/testing (v8.30.0 => v8.30.1)
