### PR TITLE
composer update 2021-04-08

### DIFF
--- a/update/composer.lock
+++ b/update/composer.lock
@@ -1032,7 +1032,7 @@
         },
         {
             "name": "illuminate/bus",
-            "version": "v8.36.1",
+            "version": "v8.36.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/bus.git",
@@ -1085,7 +1085,7 @@
         },
         {
             "name": "illuminate/cache",
-            "version": "v8.36.1",
+            "version": "v8.36.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/cache.git",
@@ -1142,7 +1142,7 @@
         },
         {
             "name": "illuminate/collections",
-            "version": "v8.36.1",
+            "version": "v8.36.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/collections.git",
@@ -1196,7 +1196,7 @@
         },
         {
             "name": "illuminate/config",
-            "version": "v8.36.1",
+            "version": "v8.36.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/config.git",
@@ -1244,7 +1244,7 @@
         },
         {
             "name": "illuminate/console",
-            "version": "v8.36.1",
+            "version": "v8.36.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/console.git",
@@ -1304,7 +1304,7 @@
         },
         {
             "name": "illuminate/container",
-            "version": "v8.36.1",
+            "version": "v8.36.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/container.git",
@@ -1355,7 +1355,7 @@
         },
         {
             "name": "illuminate/contracts",
-            "version": "v8.36.1",
+            "version": "v8.36.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/contracts.git",
@@ -1403,7 +1403,7 @@
         },
         {
             "name": "illuminate/events",
-            "version": "v8.36.1",
+            "version": "v8.36.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/events.git",
@@ -1458,7 +1458,7 @@
         },
         {
             "name": "illuminate/filesystem",
-            "version": "v8.36.1",
+            "version": "v8.36.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/filesystem.git",
@@ -1520,7 +1520,7 @@
         },
         {
             "name": "illuminate/macroable",
-            "version": "v8.36.1",
+            "version": "v8.36.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/macroable.git",
@@ -1566,7 +1566,7 @@
         },
         {
             "name": "illuminate/pipeline",
-            "version": "v8.36.1",
+            "version": "v8.36.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/pipeline.git",
@@ -1614,7 +1614,7 @@
         },
         {
             "name": "illuminate/support",
-            "version": "v8.36.1",
+            "version": "v8.36.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/support.git",
@@ -1682,7 +1682,7 @@
         },
         {
             "name": "illuminate/testing",
-            "version": "v8.36.1",
+            "version": "v8.36.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/testing.git",


### PR DESCRIPTION
  - Upgrading illuminate/bus (v8.36.1 => v8.36.2)
  - Upgrading illuminate/cache (v8.36.1 => v8.36.2)
  - Upgrading illuminate/collections (v8.36.1 => v8.36.2)
  - Upgrading illuminate/config (v8.36.1 => v8.36.2)
  - Upgrading illuminate/console (v8.36.1 => v8.36.2)
  - Upgrading illuminate/container (v8.36.1 => v8.36.2)
  - Upgrading illuminate/contracts (v8.36.1 => v8.36.2)
  - Upgrading illuminate/events (v8.36.1 => v8.36.2)
  - Upgrading illuminate/filesystem (v8.36.1 => v8.36.2)
  - Upgrading illuminate/macroable (v8.36.1 => v8.36.2)
  - Upgrading illuminate/pipeline (v8.36.1 => v8.36.2)
  - Upgrading illuminate/support (v8.36.1 => v8.36.2)
  - Upgrading illuminate/testing (v8.36.1 => v8.36.2)
