### PR TITLE
composer update 2021-04-14

### DIFF
--- a/update/composer.lock
+++ b/update/composer.lock
@@ -1032,7 +1032,7 @@
         },
         {
             "name": "illuminate/bus",
-            "version": "v8.36.2",
+            "version": "v8.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/bus.git",
@@ -1085,7 +1085,7 @@
         },
         {
             "name": "illuminate/cache",
-            "version": "v8.36.2",
+            "version": "v8.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/cache.git",
@@ -1142,7 +1142,7 @@
         },
         {
             "name": "illuminate/collections",
-            "version": "v8.36.2",
+            "version": "v8.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/collections.git",
@@ -1196,7 +1196,7 @@
         },
         {
             "name": "illuminate/config",
-            "version": "v8.36.2",
+            "version": "v8.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/config.git",
@@ -1244,7 +1244,7 @@
         },
         {
             "name": "illuminate/console",
-            "version": "v8.36.2",
+            "version": "v8.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/console.git",
@@ -1304,7 +1304,7 @@
         },
         {
             "name": "illuminate/container",
-            "version": "v8.36.2",
+            "version": "v8.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/container.git",
@@ -1355,7 +1355,7 @@
         },
         {
             "name": "illuminate/contracts",
-            "version": "v8.36.2",
+            "version": "v8.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/contracts.git",
@@ -1403,7 +1403,7 @@
         },
         {
             "name": "illuminate/events",
-            "version": "v8.36.2",
+            "version": "v8.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/events.git",
@@ -1458,7 +1458,7 @@
         },
         {
             "name": "illuminate/filesystem",
-            "version": "v8.36.2",
+            "version": "v8.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/filesystem.git",
@@ -1520,7 +1520,7 @@
         },
         {
             "name": "illuminate/macroable",
-            "version": "v8.36.2",
+            "version": "v8.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/macroable.git",
@@ -1566,7 +1566,7 @@
         },
         {
             "name": "illuminate/pipeline",
-            "version": "v8.36.2",
+            "version": "v8.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/pipeline.git",
@@ -1614,16 +1614,16 @@
         },
         {
             "name": "illuminate/support",
-            "version": "v8.36.2",
+            "version": "v8.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/support.git",
-                "reference": "26aa01648f348df7b7988ee911cdf98bcaae8ea1"
+                "reference": "074a9b7adefcdd7108e19faa96bc9dacfe922062"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/support/zipball/26aa01648f348df7b7988ee911cdf98bcaae8ea1",
-                "reference": "26aa01648f348df7b7988ee911cdf98bcaae8ea1",
+                "url": "https://api.github.com/repos/illuminate/support/zipball/074a9b7adefcdd7108e19faa96bc9dacfe922062",
+                "reference": "074a9b7adefcdd7108e19faa96bc9dacfe922062",
                 "shasum": ""
             },
             "require": {
@@ -1678,11 +1678,11 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2021-04-06T13:05:53+00:00"
+            "time": "2021-04-11T23:26:41+00:00"
         },
         {
             "name": "illuminate/testing",
-            "version": "v8.36.2",
+            "version": "v8.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/testing.git",


### PR DESCRIPTION
  - Upgrading illuminate/bus (v8.36.2 => v8.37.0)
  - Upgrading illuminate/cache (v8.36.2 => v8.37.0)
  - Upgrading illuminate/collections (v8.36.2 => v8.37.0)
  - Upgrading illuminate/config (v8.36.2 => v8.37.0)
  - Upgrading illuminate/console (v8.36.2 => v8.37.0)
  - Upgrading illuminate/container (v8.36.2 => v8.37.0)
  - Upgrading illuminate/contracts (v8.36.2 => v8.37.0)
  - Upgrading illuminate/events (v8.36.2 => v8.37.0)
  - Upgrading illuminate/filesystem (v8.36.2 => v8.37.0)
  - Upgrading illuminate/macroable (v8.36.2 => v8.37.0)
  - Upgrading illuminate/pipeline (v8.36.2 => v8.37.0)
  - Upgrading illuminate/support (v8.36.2 => v8.37.0)
  - Upgrading illuminate/testing (v8.36.2 => v8.37.0)
