### PR TITLE
[FEATURE] Keep updating the same branch and pull request

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,15 @@
 FROM php:7.4-cli
 
 # php
-RUN apt-get update \
-    && apt-get install -yq \
-        git \
-        libzip-dev \
-        zlib1g-dev \
-        libgmp-dev \
-        unzip \
-        libicu-dev\
-        libfreetype6-dev \
-        libjpeg62-turbo-dev \
-        libpng-dev \
-    && docker-php-ext-configure zip \
-    && docker-php-ext-configure gd --with-freetype --with-jpeg \
-    && docker-php-ext-install -j$(nproc) zip pdo_mysql bcmath pcntl gmp intl gd sockets
+RUN apt-get install -yq git
 
 # composer
 COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
 
-RUN composer self-update --2
-
 WORKDIR /root
 COPY ./update /root
 
-RUN composer install --no-dev --no-interaction --no-progress --optimize-autoloader
+RUN composer install --no-dev --no-interaction --no-progress
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
 WORKDIR /root
 COPY ./update /root
 
-RUN composer install --no-dev --no-interaction --no-progress
+RUN composer install --no-dev --no-interaction --no-progress --no-scripts
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,9 @@ FROM php:7.4-cli
 
 # php
 RUN apt-get update
-RUN apt-get install -yq git
+RUN apt-get install -yq git libzip-dev unzip
+RUN docker-php-ext-install zip
+RUN docker-php-ext-install -j$(nproc) zip
 
 # composer
 COPY --from=composer:latest /usr/bin/composer /usr/bin/composer

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM php:7.4-cli
 
 # php
+RUN apt-get update
 RUN apt-get install -yq git
 
 # composer

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ jobs:
 - COMPOSER_PATH : Specify if using subdirectory. Where composer.json is located.
 - GIT_NAME : git user name
 - GIT_EMAIL : git email
+- APP_SINGLE_BRANCH : If set, the new functionality is enabled.
+- APP_SINGLE_BRANCH_POSTFIX : A postfix for the branch used for updates. Default value is "-updated". If the branch doesn't exist, a new branch will be created with the parent branch name plus the postfix, e.g. "master-updated".
+- GIT_COMMIT_PREFIX : Add a prefix to the commit message and pull request title. E.g. "[UPDATE] "
+- COMPOSER_PACKAGES : Specify which packages should be updated. E.g. "typo3/cms-*". Setting this variable will also run Composer with the `--with-dependencies` argument.
 
 ```yaml
       - name: composer update action
@@ -51,6 +55,10 @@ jobs:
           COMPOSER_PATH: /subdir
           GIT_NAME: cu
           GIT_EMAIL: cu@composer-update
+          APP_SINGLE_BRANCH: 1
+          APP_SINGLE_BRANCH_POSTFIX: -updated
+          GIT_COMMIT_PREFIX: '[UPDATE] '
+          COMPOSER_PACKAGES: 'typo3/cms-*'
 ```
 
 ## Troubleshooting

--- a/update/app/Commands/UpdateCommand.php
+++ b/update/app/Commands/UpdateCommand.php
@@ -265,11 +265,15 @@ class UpdateCommand extends Command
         }
 
         if ($createPullRequest) {
-            GitHub::pullRequest()->create(
+            $result = GitHub::pullRequest()->create(
                 Str::before($this->repo, '/'),
                 Str::afterLast($this->repo, '/'),
                 $pullData
             );
+
+            $this->info('Pull request created for branch "' . $this->new_branch . '": ' . $result[0]['html_url']);
+        } else {
+            $this->info('Pull request already exists for branch "' . $this->new_branch . '": ' . $pullRequests[0]['html_url']);
         }
     }
 }

--- a/update/app/Commands/UpdateCommand.php
+++ b/update/app/Commands/UpdateCommand.php
@@ -118,7 +118,7 @@ class UpdateCommand extends Command
             $this->info('Creating branch "' . $this->new_branch . '".');
 
             Git::createBranch($this->new_branch, true);
-        } elseif (!env('APP_SINGLE_BRANCH')) {
+        } elseif (env('APP_SINGLE_BRANCH')) {
             $this->info('Fetching from remote.');
 
             Git::fetch('origin');

--- a/update/app/Commands/UpdateCommand.php
+++ b/update/app/Commands/UpdateCommand.php
@@ -257,6 +257,8 @@ class UpdateCommand extends Command
                 ]
             );
 
+            $this->info(var_export($pullRequests, true));
+
             if (count($pullRequests) > 0) {
                 $createPullRequest = false;
             }

--- a/update/app/Commands/UpdateCommand.php
+++ b/update/app/Commands/UpdateCommand.php
@@ -61,8 +61,6 @@ class UpdateCommand extends Command
             return;
         }
 
-        $this->process('install');
-
         $output = $this->process(
             'update',
             [
@@ -74,7 +72,7 @@ class UpdateCommand extends Command
         $this->output($output);
 
         if (! Git::hasChanges()) {
-            $this->info('no changes');
+            $this->info('No changes after update.');
 
             return;
         }
@@ -89,7 +87,7 @@ class UpdateCommand extends Command
      */
     protected function init(): void
     {
-        $this->info('init');
+        $this->info('Initializing ...');
 
         $this->repo = env('GITHUB_REPOSITORY', '');
 
@@ -121,12 +119,16 @@ class UpdateCommand extends Command
 
             Git::createBranch($this->new_branch, true);
         } elseif (!env('APP_SINGLE_BRANCH')) {
+            $this->info('Fetching from remote.');
+
+            Git::fetch('origin');
+
             $this->info('Merging from "' . $this->parent_branch . '".');
 
             Git::checkout($this->new_branch);
 
             Git::merge($this->parent_branch, [
-                '--strategy=theirs',
+                '--strategy-option=theirs',
                 '--quiet',
             ]);
         }
@@ -211,7 +213,7 @@ class UpdateCommand extends Command
      */
     protected function commitPush(): void
     {
-        $this->info('commit');
+        $this->info('Committing changes ...');
 
         Git::addAllChanges()
            ->commit(env('GIT_COMMIT_PREFIX', '') . 'composer update ' . today()->toDateString() . PHP_EOL . PHP_EOL . $this->out)

--- a/update/app/Commands/UpdateCommand.php
+++ b/update/app/Commands/UpdateCommand.php
@@ -236,12 +236,14 @@ class UpdateCommand extends Command
     {
         $this->info('Pull Request');
 
-        $date = env('APP_SINGLE_BRANCH') ? '' : today()->toDateString();
+        $date = env('APP_SINGLE_BRANCH') ? '' : ' ' . today()->toDateString();
 
         $pullData = [
             'base'  => Str::afterLast(env('GITHUB_REF'), '/'),
             'head'  => $this->new_branch,
-            'title' => env('GIT_COMMIT_PREFIX', '') . 'Composer update ' . $date,
+            'title' => env('GIT_COMMIT_PREFIX', '') . 'Composer update with '
+                . (count(explode(PHP_EOL, $this->out)) - 1) . ' changes'
+                . $date,
             'body'  => $this->out,
         ];
 
@@ -271,7 +273,7 @@ class UpdateCommand extends Command
                 $pullData
             );
 
-            $this->info('Pull request created for branch "' . $this->new_branch . '": ' . $result[0]['html_url']);
+            $this->info('Pull request created for branch "' . $this->new_branch . '": ' . $result['html_url']);
         } else {
             $this->info('Pull request already exists for branch "' . $this->new_branch . '": ' . $pullRequests[0]['html_url']);
         }

--- a/update/app/Commands/UpdateCommand.php
+++ b/update/app/Commands/UpdateCommand.php
@@ -213,7 +213,7 @@ class UpdateCommand extends Command
 
         Git::addAllChanges()
            ->commit(env('GIT_COMMIT_PREFIX', '') . 'composer update ' . today()->toDateString() . PHP_EOL . PHP_EOL . $this->out)
-           ->push('origin', [$this->new_branch]);
+           ->push('origin', [$this->new_branch, '--force']);
     }
 
     /**

--- a/update/app/Commands/UpdateCommand.php
+++ b/update/app/Commands/UpdateCommand.php
@@ -212,7 +212,7 @@ class UpdateCommand extends Command
         $this->info('commit');
 
         Git::addAllChanges()
-           ->commit(env(GIT_COMMIT_PREFIX, '') . 'composer update ' . today()->toDateString() . PHP_EOL . PHP_EOL . $this->out)
+           ->commit(env('GIT_COMMIT_PREFIX', '') . 'composer update ' . today()->toDateString() . PHP_EOL . PHP_EOL . $this->out)
            ->push('origin', [$this->new_branch]);
     }
 
@@ -228,7 +228,7 @@ class UpdateCommand extends Command
         $pullData = [
             'base'  => Str::afterLast(env('GITHUB_REF'), '/'),
             'head'  => $this->new_branch,
-            'title' => env(GIT_COMMIT_PREFIX, '') . 'Composer update ' . $date,
+            'title' => env('GIT_COMMIT_PREFIX', '') . 'Composer update ' . $date,
             'body'  => $this->out,
         ];
 

--- a/update/app/Commands/UpdateCommand.php
+++ b/update/app/Commands/UpdateCommand.php
@@ -101,7 +101,7 @@ class UpdateCommand extends Command
         if (env('APP_SINGLE_BRANCH')) {
             $this->new_branch = $this->parent_branch . env('APP_SINGLE_BRANCH_POSTFIX', '-updated');
 
-            $this->info('Using single-branch approach. Branch name: ' . $this->new_branch);
+            $this->info('Using single-branch approach. Branch name: "' . $this->new_branch . '"');
         }
 
         $token = env('GITHUB_TOKEN');
@@ -117,11 +117,13 @@ class UpdateCommand extends Command
         Git::execute(['config', '--local', 'user.email', env('GIT_EMAIL', 'cu@composer-update')]);
 
         if (!env('APP_SINGLE_BRANCH') || !in_array($this->new_branch, Git::getBranches() ?? [])) {
-            $this->info('Creating branch ' . $this->new_branch);
+            $this->info('Creating branch "' . $this->new_branch . '".');
 
             Git::createBranch($this->new_branch, true);
         } elseif (!env('APP_SINGLE_BRANCH')) {
-            $this->info('Merging from ' . $this->parent_branch);
+            $this->info('Merging from "' . $this->parent_branch . '".');
+
+            Git::checkout($this->new_branch);
 
             Git::merge($this->parent_branch, [
                 '--strategy=theirs',
@@ -213,7 +215,7 @@ class UpdateCommand extends Command
 
         Git::addAllChanges()
            ->commit(env('GIT_COMMIT_PREFIX', '') . 'composer update ' . today()->toDateString() . PHP_EOL . PHP_EOL . $this->out)
-           ->push('origin', [$this->new_branch, '--force']);
+           ->push('origin', [$this->new_branch]);
     }
 
     /**

--- a/update/app/Commands/UpdateCommand.php
+++ b/update/app/Commands/UpdateCommand.php
@@ -113,6 +113,7 @@ class UpdateCommand extends Command
 
         Git::execute(['config', '--local', 'user.name', env('GIT_NAME', 'cu')]);
         Git::execute(['config', '--local', 'user.email', env('GIT_EMAIL', 'cu@composer-update')]);
+        Git::fetch('origin');
         $this->info(var_export(Git::getBranches(), true));
         if (!env('APP_SINGLE_BRANCH') || !in_array($this->new_branch, Git::getBranches() ?? [])) {
             $this->info('Creating branch "' . $this->new_branch . '".');

--- a/update/app/Commands/UpdateCommand.php
+++ b/update/app/Commands/UpdateCommand.php
@@ -113,20 +113,28 @@ class UpdateCommand extends Command
 
         Git::execute(['config', '--local', 'user.name', env('GIT_NAME', 'cu')]);
         Git::execute(['config', '--local', 'user.email', env('GIT_EMAIL', 'cu@composer-update')]);
+
+        $this->info('Fetching from remote.');
+
         Git::fetch('origin');
-        $this->info(var_export(Git::getBranches(), true));
-        if (!env('APP_SINGLE_BRANCH') || !in_array($this->new_branch, Git::getBranches() ?? [])) {
+
+        if (
+            !env('APP_SINGLE_BRANCH')
+            || !in_array('remotes/origin/' . $this->new_branch, Git::getBranches() ?? [])
+        ) {
             $this->info('Creating branch "' . $this->new_branch . '".');
 
             Git::createBranch($this->new_branch, true);
         } elseif (env('APP_SINGLE_BRANCH')) {
-            $this->info('Fetching from remote.');
-
-            Git::fetch('origin');
-
-            $this->info('Merging from "' . $this->parent_branch . '".');
+            $this->info('Checking out branch "' . $this->new_branch . '".');
 
             Git::checkout($this->new_branch);
+
+            $this->info('Pulling from origin.');
+
+            Git::pull('origin');
+
+            $this->info('Merging from "' . $this->parent_branch . '".');
 
             Git::merge($this->parent_branch, [
                 '--strategy-option=theirs',

--- a/update/app/Commands/UpdateCommand.php
+++ b/update/app/Commands/UpdateCommand.php
@@ -252,7 +252,7 @@ class UpdateCommand extends Command
                 Str::before($this->repo, '/'),
                 Str::afterLast($this->repo, '/'),
                 [
-                    'base' => $this->parent_branch,
+                    'head' => Str::before($this->repo, '/') . ':' . $this->new_branch,
                     'state' => 'open'
                 ]
             );

--- a/update/app/Commands/UpdateCommand.php
+++ b/update/app/Commands/UpdateCommand.php
@@ -113,7 +113,7 @@ class UpdateCommand extends Command
 
         Git::execute(['config', '--local', 'user.name', env('GIT_NAME', 'cu')]);
         Git::execute(['config', '--local', 'user.email', env('GIT_EMAIL', 'cu@composer-update')]);
-
+        $this->info(var_export(Git::getBranches(), true));
         if (!env('APP_SINGLE_BRANCH') || !in_array($this->new_branch, Git::getBranches() ?? [])) {
             $this->info('Creating branch "' . $this->new_branch . '".');
 

--- a/update/app/Commands/UpdateCommand.php
+++ b/update/app/Commands/UpdateCommand.php
@@ -259,8 +259,6 @@ class UpdateCommand extends Command
                 ]
             );
 
-            $this->info(var_export($pullRequests, true));
-
             if (count($pullRequests) > 0) {
                 $createPullRequest = false;
             }


### PR DESCRIPTION
* Introduces a number of new configurations and changes to the code that allows changes to be applied to the same pull request. The benefit of this is that you don't end up with lots of environments for different pull requests in continuous deployment settings.
* The Dockerfile has also been simplified for increased speed.
* Introduces a possibility to define a commit message prefix, such as "[UPDATE] " or "[TASK] ".

This PR has only been tested with the v1 branch and PHP 7.4, not with v2 and PHP 8.

For a full overview of changes to configuration options, please check the changes to the readme file.