### PR TITLE
Composer update with 13 changes 2021-11-21

### DIFF
--- a/update/composer.lock
+++ b/update/composer.lock
@@ -1127,7 +1127,7 @@
         },
         {
             "name": "illuminate/bus",
-            "version": "v8.73.0",
+            "version": "v8.73.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/bus.git",
@@ -1180,7 +1180,7 @@
         },
         {
             "name": "illuminate/cache",
-            "version": "v8.73.0",
+            "version": "v8.73.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/cache.git",
@@ -1240,7 +1240,7 @@
         },
         {
             "name": "illuminate/collections",
-            "version": "v8.73.0",
+            "version": "v8.73.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/collections.git",
@@ -1294,7 +1294,7 @@
         },
         {
             "name": "illuminate/config",
-            "version": "v8.73.0",
+            "version": "v8.73.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/config.git",
@@ -1342,7 +1342,7 @@
         },
         {
             "name": "illuminate/console",
-            "version": "v8.73.0",
+            "version": "v8.73.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/console.git",
@@ -1402,7 +1402,7 @@
         },
         {
             "name": "illuminate/container",
-            "version": "v8.73.0",
+            "version": "v8.73.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/container.git",
@@ -1453,7 +1453,7 @@
         },
         {
             "name": "illuminate/contracts",
-            "version": "v8.73.0",
+            "version": "v8.73.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/contracts.git",
@@ -1501,7 +1501,7 @@
         },
         {
             "name": "illuminate/events",
-            "version": "v8.73.0",
+            "version": "v8.73.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/events.git",
@@ -1556,7 +1556,7 @@
         },
         {
             "name": "illuminate/filesystem",
-            "version": "v8.73.0",
+            "version": "v8.73.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/filesystem.git",
@@ -1618,7 +1618,7 @@
         },
         {
             "name": "illuminate/macroable",
-            "version": "v8.73.0",
+            "version": "v8.73.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/macroable.git",
@@ -1664,7 +1664,7 @@
         },
         {
             "name": "illuminate/pipeline",
-            "version": "v8.73.0",
+            "version": "v8.73.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/pipeline.git",
@@ -1712,7 +1712,7 @@
         },
         {
             "name": "illuminate/support",
-            "version": "v8.73.0",
+            "version": "v8.73.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/support.git",
@@ -1780,7 +1780,7 @@
         },
         {
             "name": "illuminate/testing",
-            "version": "v8.73.0",
+            "version": "v8.73.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/testing.git",


### PR DESCRIPTION
  - Upgrading illuminate/bus (v8.73.0 => v8.73.1)
  - Upgrading illuminate/cache (v8.73.0 => v8.73.1)
  - Upgrading illuminate/collections (v8.73.0 => v8.73.1)
  - Upgrading illuminate/config (v8.73.0 => v8.73.1)
  - Upgrading illuminate/console (v8.73.0 => v8.73.1)
  - Upgrading illuminate/container (v8.73.0 => v8.73.1)
  - Upgrading illuminate/contracts (v8.73.0 => v8.73.1)
  - Upgrading illuminate/events (v8.73.0 => v8.73.1)
  - Upgrading illuminate/filesystem (v8.73.0 => v8.73.1)
  - Upgrading illuminate/macroable (v8.73.0 => v8.73.1)
  - Upgrading illuminate/pipeline (v8.73.0 => v8.73.1)
  - Upgrading illuminate/support (v8.73.0 => v8.73.1)
  - Upgrading illuminate/testing (v8.73.0 => v8.73.1)
