### PR TITLE
Composer update with 15 changes 2022-05-12

### DIFF
--- a/update/composer.lock
+++ b/update/composer.lock
@@ -1131,7 +1131,7 @@
         },
         {
             "name": "illuminate/bus",
-            "version": "v9.12.1",
+            "version": "v9.12.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/bus.git",
@@ -1184,7 +1184,7 @@
         },
         {
             "name": "illuminate/cache",
-            "version": "v9.12.1",
+            "version": "v9.12.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/cache.git",
@@ -1244,7 +1244,7 @@
         },
         {
             "name": "illuminate/collections",
-            "version": "v9.12.1",
+            "version": "v9.12.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/collections.git",
@@ -1299,7 +1299,7 @@
         },
         {
             "name": "illuminate/conditionable",
-            "version": "v9.12.1",
+            "version": "v9.12.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/conditionable.git",
@@ -1345,7 +1345,7 @@
         },
         {
             "name": "illuminate/config",
-            "version": "v9.12.1",
+            "version": "v9.12.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/config.git",
@@ -1393,7 +1393,7 @@
         },
         {
             "name": "illuminate/console",
-            "version": "v9.12.1",
+            "version": "v9.12.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/console.git",
@@ -1453,7 +1453,7 @@
         },
         {
             "name": "illuminate/container",
-            "version": "v9.12.1",
+            "version": "v9.12.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/container.git",
@@ -1504,7 +1504,7 @@
         },
         {
             "name": "illuminate/contracts",
-            "version": "v9.12.1",
+            "version": "v9.12.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/contracts.git",
@@ -1552,7 +1552,7 @@
         },
         {
             "name": "illuminate/events",
-            "version": "v9.12.1",
+            "version": "v9.12.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/events.git",
@@ -1607,7 +1607,7 @@
         },
         {
             "name": "illuminate/filesystem",
-            "version": "v9.12.1",
+            "version": "v9.12.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/filesystem.git",
@@ -1669,7 +1669,7 @@
         },
         {
             "name": "illuminate/macroable",
-            "version": "v9.12.1",
+            "version": "v9.12.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/macroable.git",
@@ -1715,7 +1715,7 @@
         },
         {
             "name": "illuminate/pipeline",
-            "version": "v9.12.1",
+            "version": "v9.12.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/pipeline.git",
@@ -1763,7 +1763,7 @@
         },
         {
             "name": "illuminate/support",
-            "version": "v9.12.1",
+            "version": "v9.12.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/support.git",
@@ -1832,7 +1832,7 @@
         },
         {
             "name": "illuminate/testing",
-            "version": "v9.12.1",
+            "version": "v9.12.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/testing.git",
@@ -2705,16 +2705,16 @@
         },
         {
             "name": "nunomaduro/termwind",
-            "version": "v1.9.0",
+            "version": "v1.10.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nunomaduro/termwind.git",
-                "reference": "7d7c5f846158a764bdd0cd943685c381de9be656"
+                "reference": "b63e00e448af1d418cbb07a683187685a97ca0e6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nunomaduro/termwind/zipball/7d7c5f846158a764bdd0cd943685c381de9be656",
-                "reference": "7d7c5f846158a764bdd0cd943685c381de9be656",
+                "url": "https://api.github.com/repos/nunomaduro/termwind/zipball/b63e00e448af1d418cbb07a683187685a97ca0e6",
+                "reference": "b63e00e448af1d418cbb07a683187685a97ca0e6",
                 "shasum": ""
             },
             "require": {
@@ -2771,7 +2771,7 @@
             ],
             "support": {
                 "issues": "https://github.com/nunomaduro/termwind/issues",
-                "source": "https://github.com/nunomaduro/termwind/tree/v1.9.0"
+                "source": "https://github.com/nunomaduro/termwind/tree/v1.10.1"
             },
             "funding": [
                 {
@@ -2787,7 +2787,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-05-03T00:11:55+00:00"
+            "time": "2022-05-12T01:36:04+00:00"
         },
         {
             "name": "php-http/cache-plugin",


### PR DESCRIPTION
  - Upgrading illuminate/bus (v9.12.1 => v9.12.2)
  - Upgrading illuminate/cache (v9.12.1 => v9.12.2)
  - Upgrading illuminate/collections (v9.12.1 => v9.12.2)
  - Upgrading illuminate/conditionable (v9.12.1 => v9.12.2)
  - Upgrading illuminate/config (v9.12.1 => v9.12.2)
  - Upgrading illuminate/console (v9.12.1 => v9.12.2)
  - Upgrading illuminate/container (v9.12.1 => v9.12.2)
  - Upgrading illuminate/contracts (v9.12.1 => v9.12.2)
  - Upgrading illuminate/events (v9.12.1 => v9.12.2)
  - Upgrading illuminate/filesystem (v9.12.1 => v9.12.2)
  - Upgrading illuminate/macroable (v9.12.1 => v9.12.2)
  - Upgrading illuminate/pipeline (v9.12.1 => v9.12.2)
  - Upgrading illuminate/support (v9.12.1 => v9.12.2)
  - Upgrading illuminate/testing (v9.12.1 => v9.12.2)
  - Upgrading nunomaduro/termwind (v1.9.0 => v1.10.1)
