### PR TITLE
Composer update with 15 changes 2022-10-20

### DIFF
--- a/update/composer.lock
+++ b/update/composer.lock
@@ -1082,7 +1082,7 @@
         },
         {
             "name": "illuminate/bus",
-            "version": "v9.36.2",
+            "version": "v9.36.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/bus.git",
@@ -1135,7 +1135,7 @@
         },
         {
             "name": "illuminate/cache",
-            "version": "v9.36.2",
+            "version": "v9.36.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/cache.git",
@@ -1195,7 +1195,7 @@
         },
         {
             "name": "illuminate/collections",
-            "version": "v9.36.2",
+            "version": "v9.36.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/collections.git",
@@ -1250,7 +1250,7 @@
         },
         {
             "name": "illuminate/conditionable",
-            "version": "v9.36.2",
+            "version": "v9.36.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/conditionable.git",
@@ -1296,7 +1296,7 @@
         },
         {
             "name": "illuminate/config",
-            "version": "v9.36.2",
+            "version": "v9.36.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/config.git",
@@ -1344,7 +1344,7 @@
         },
         {
             "name": "illuminate/console",
-            "version": "v9.36.2",
+            "version": "v9.36.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/console.git",
@@ -1406,7 +1406,7 @@
         },
         {
             "name": "illuminate/container",
-            "version": "v9.36.2",
+            "version": "v9.36.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/container.git",
@@ -1457,7 +1457,7 @@
         },
         {
             "name": "illuminate/contracts",
-            "version": "v9.36.2",
+            "version": "v9.36.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/contracts.git",
@@ -1505,7 +1505,7 @@
         },
         {
             "name": "illuminate/events",
-            "version": "v9.36.2",
+            "version": "v9.36.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/events.git",
@@ -1560,7 +1560,7 @@
         },
         {
             "name": "illuminate/filesystem",
-            "version": "v9.36.2",
+            "version": "v9.36.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/filesystem.git",
@@ -1622,7 +1622,7 @@
         },
         {
             "name": "illuminate/macroable",
-            "version": "v9.36.2",
+            "version": "v9.36.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/macroable.git",
@@ -1668,7 +1668,7 @@
         },
         {
             "name": "illuminate/pipeline",
-            "version": "v9.36.2",
+            "version": "v9.36.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/pipeline.git",
@@ -1716,7 +1716,7 @@
         },
         {
             "name": "illuminate/support",
-            "version": "v9.36.2",
+            "version": "v9.36.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/support.git",
@@ -1786,7 +1786,7 @@
         },
         {
             "name": "illuminate/testing",
-            "version": "v9.36.2",
+            "version": "v9.36.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/testing.git",
@@ -1844,16 +1844,16 @@
         },
         {
             "name": "illuminate/view",
-            "version": "v9.36.2",
+            "version": "v9.36.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/view.git",
-                "reference": "bb6088d006806972fbda29f8793cd578206688af"
+                "reference": "935608accf327a1c1cb20376a831aa419bcc64e5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/view/zipball/bb6088d006806972fbda29f8793cd578206688af",
-                "reference": "bb6088d006806972fbda29f8793cd578206688af",
+                "url": "https://api.github.com/repos/illuminate/view/zipball/935608accf327a1c1cb20376a831aa419bcc64e5",
+                "reference": "935608accf327a1c1cb20376a831aa419bcc64e5",
                 "shasum": ""
             },
             "require": {
@@ -1894,7 +1894,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-10-18T16:03:56+00:00"
+            "time": "2022-10-19T13:21:05+00:00"
         },
         {
             "name": "jolicode/jolinotif",


### PR DESCRIPTION
  - Upgrading illuminate/bus (v9.36.2 => v9.36.3)
  - Upgrading illuminate/cache (v9.36.2 => v9.36.3)
  - Upgrading illuminate/collections (v9.36.2 => v9.36.3)
  - Upgrading illuminate/conditionable (v9.36.2 => v9.36.3)
  - Upgrading illuminate/config (v9.36.2 => v9.36.3)
  - Upgrading illuminate/console (v9.36.2 => v9.36.3)
  - Upgrading illuminate/container (v9.36.2 => v9.36.3)
  - Upgrading illuminate/contracts (v9.36.2 => v9.36.3)
  - Upgrading illuminate/events (v9.36.2 => v9.36.3)
  - Upgrading illuminate/filesystem (v9.36.2 => v9.36.3)
  - Upgrading illuminate/macroable (v9.36.2 => v9.36.3)
  - Upgrading illuminate/pipeline (v9.36.2 => v9.36.3)
  - Upgrading illuminate/support (v9.36.2 => v9.36.3)
  - Upgrading illuminate/testing (v9.36.2 => v9.36.3)
  - Upgrading illuminate/view (v9.36.2 => v9.36.3)
