### PR TITLE
fix: safe directory

### DIFF
--- a/update/app/Commands/UpdateCommand.php
+++ b/update/app/Commands/UpdateCommand.php
@@ -97,6 +97,9 @@ class UpdateCommand extends Command
 
         $this->base_path = env('GITHUB_WORKSPACE', '').env('COMPOSER_PATH', '');
 
+        Git::execute('config', '--global', '--add', 'safe.directory', env('GITHUB_WORKSPACE', ''));
+        Git::execute('config', '--global', '--add', 'safe.directory', $this->base_path);
+
         $this->parent_branch = Git::getCurrentBranchName();
 
         $this->new_branch = 'cu/'.Str::random(8);


### PR DESCRIPTION
This PR solves the following issue https://github.com/kawax/composer-update-action/actions/runs/4100227845/jobs/7070853029#step:4:13

It seems the ubuntu images updated the git version and now is complaining about the workspace directory is not in the whitelist of safe directories

I hope this can be also merged in the previous PHP version branches

Let me know if this PR is good enough I couldn't find a contribution guide thanks @kawax 